### PR TITLE
ci: fix artifact action SHA by using v4 tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
           ./dist/llm-cost-${{ matrix.suffix }} tokens --model gpt-4o <<< "Hello world"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: llm-cost-${{ matrix.suffix }}-signed
           path: |
@@ -139,7 +139,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: artifacts
 


### PR DESCRIPTION
Fixes failing release workflow by replacing invalid SHAs with stable @v4 tags.